### PR TITLE
use branch name not commit number for internal projects

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -4,17 +4,17 @@ Babel==0.9.6
 Beaker==1.6.4
 celery==2.4.2
 chardet==2.3.0
--e git+https://github.com/GSA/ckan.git@2.3-upgrade#egg=ckan
--e git+https://github.com/GSA/ckanext-archiver@2.3-upgrade#egg=ckanext_archiver
--e git+https://github.com/GSA/ckanext-datagovtheme@2.3-upgrade#egg=ckanext_datagovtheme
--e git+https://github.com/GSA/ckanext-datajson@2.3-upgrade#egg=ckanext_datajson
+-e git+https://github.com/GSA/ckan.git@datagov#egg=ckan
+-e git+https://github.com/GSA/ckanext-archiver@datagov#egg=ckanext_archiver
+-e git+https://github.com/GSA/ckanext-datagovtheme@master#egg=ckanext_datagovtheme
+-e git+https://github.com/GSA/ckanext-datajson@datagov#egg=ckanext_datajson
 -e git+https://github.com/GSA/ckanext-extlink@master#egg=ckanext_extlink
--e git+https://github.com/GSA/ckanext-geodatagov@2.3-upgrade#egg=ckanext_geodatagov
+-e git+https://github.com/GSA/ckanext-geodatagov@master#egg=ckanext_geodatagov
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@master#egg=ckanext_googleanalyticsbasic
--e git+https://github.com/GSA/ckanext-harvest@2.3-upgrade#egg=ckanext_harvest
--e git+https://github.com/GSA/ckanext-qa@2.3-upgrade#egg=ckanext_qa
--e git+https://github.com/GSA/ckanext-report@2.3-upgrade#egg=ckanext_report
--e git+https://github.com/GSA/ckanext-spatial@2.3-upgrade#egg=ckanext_spatial
+-e git+https://github.com/GSA/ckanext-harvest@datagov#egg=ckanext_harvest
+-e git+https://github.com/GSA/ckanext-qa@datagov#egg=ckanext_qa
+-e git+https://github.com/GSA/ckanext-report@datagov#egg=ckanext_report
+-e git+https://github.com/GSA/ckanext-spatial@datagov#egg=ckanext_spatial
 -e git+https://github.com/GSA/ckanext-ga-report@datagov#egg=ckanext_ga_report
 decorator==3.4.0
 fanstatic==0.12

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -2,6 +2,7 @@ amqplib==1.0.2
 anyjson==0.3.3
 Babel==0.9.6
 Beaker==1.6.4
+boto==2.48.0
 celery==2.4.2
 chardet==2.3.0
 -e git+https://github.com/GSA/ckan.git@datagov#egg=ckan

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -4,18 +4,18 @@ Babel==0.9.6
 Beaker==1.6.4
 celery==2.4.2
 chardet==2.3.0
--e git+https://github.com/GSA/ckan.git@3d3424fc2d43909adb88878775ef99e114e97ae1#egg=ckan
--e git+https://github.com/GSA/ckanext-archiver@bb4d85b5db628cd2a6d576c3fde79ddc0d9b5952#egg=ckanext_archiver
--e git+https://github.com/GSA/ckanext-datagovtheme@35a44a5814e9cd55fb55a53281a82dee550abea0#egg=ckanext_datagovtheme
--e git+https://github.com/GSA/ckanext-datajson@3205ba3f9af9c37fb0adaed3023c701c23c5cc21#egg=ckanext_datajson
--e git+https://github.com/GSA/ckanext-extlink@69629853f6c7aa4f94c105c5efd76380d70f0843#egg=ckanext_extlink
--e git+https://github.com/GSA/ckanext-geodatagov@80b72945926134f0d9d3fb59741284332672cac4#egg=ckanext_geodatagov
--e git+https://github.com/GSA/ckanext-googleanalyticsbasic@0b90194d77938e59ecb7d6937c201bd6815447f8#egg=ckanext_googleanalyticsbasic
--e git+https://github.com/GSA/ckanext-harvest@23c646128b2c8b6f1cc6b7dac733d057dd6274c5#egg=ckanext_harvest
--e git+https://github.com/GSA/ckanext-qa@2b3353cb3a36e021de448b7d280165a3dbfcf728#egg=ckanext_qa
--e git+https://github.com/GSA/ckanext-report@f16607e700db67645734257a0c3ac74f4cbdb718#egg=ckanext_report
--e git+https://github.com/GSA/ckanext-spatial@2a25f8d60c31add77e155c4136f2c0d4e3b86385#egg=ckanext_spatial
--e git+https://github.com/GSA/ckanext-ga-report@ae0a10c9accbe045b3ebd218c825685006532c4c#egg=ckanext_ga_report
+-e git+https://github.com/GSA/ckan.git@2.3-upgrade#egg=ckan
+-e git+https://github.com/GSA/ckanext-archiver@2.3-upgrade#egg=ckanext_archiver
+-e git+https://github.com/GSA/ckanext-datagovtheme@2.3-upgrade#egg=ckanext_datagovtheme
+-e git+https://github.com/GSA/ckanext-datajson@2.3-upgrade#egg=ckanext_datajson
+-e git+https://github.com/GSA/ckanext-extlink@master#egg=ckanext_extlink
+-e git+https://github.com/GSA/ckanext-geodatagov@2.3-upgrade#egg=ckanext_geodatagov
+-e git+https://github.com/GSA/ckanext-googleanalyticsbasic@master#egg=ckanext_googleanalyticsbasic
+-e git+https://github.com/GSA/ckanext-harvest@2.3-upgrade#egg=ckanext_harvest
+-e git+https://github.com/GSA/ckanext-qa@2.3-upgrade#egg=ckanext_qa
+-e git+https://github.com/GSA/ckanext-report@2.3-upgrade#egg=ckanext_report
+-e git+https://github.com/GSA/ckanext-spatial@2.3-upgrade#egg=ckanext_spatial
+-e git+https://github.com/GSA/ckanext-ga-report@datagov#egg=ckanext_ga_report
 decorator==3.4.0
 fanstatic==0.12
 Flask==0.8


### PR DESCRIPTION
It makes sense to put a freeze on external libs. For our own repos, we want to use our release branches.