### PR TITLE
Bundle saml2 and lock dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get -q -y update && apt-get -q -y install \
   libpq-dev \
   libxml2-dev \
   libxslt1-dev \
+  memcached \
   postgresql-client \
   python-dev \
   python-pip \
@@ -31,8 +32,10 @@ RUN apt-get -q -y update && apt-get -q -y install \
   python-virtualenv \
   ruby \
   ruby-dev \
+  swig \
   tomcat6 \
-  wget
+  wget \
+  xmlsec1
 
 # copy ckan script to /usr/bin/
 COPY docker/webserver/common/usr/bin/ckan /usr/bin/ckan

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,10 @@ RUN mkdir /var/tmp/ckan && chown www-data:www-data /var/tmp/ckan
 # Install ckan app
 RUN cd / && ./install.sh
 
+# auth_tkt (and ckan) requires repoze.who 2.0. ckanext-saml, used for
+# production requires repoze.who==1.0.18
+RUN $CKAN_HOME/bin/pip install repoze.who==2.0
+
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/config/environments/docker/production.ini
+++ b/config/environments/docker/production.ini
@@ -101,7 +101,7 @@ ckan.search.solr_commit = true
 #       Add ``datapusher`` to enable DataPusher
 #		Add ``resource_proxy`` to enable resorce proxying and get around the
 #		same origin policy
-ckan.plugins = stats text_view image_view recline_view geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api recline_preview datagovtheme datajson_harvest datajson archiver qa googleanalyticsbasic extlink report broken_link_report
+ckan.plugins = stats text_view image_view recline_view geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api recline_preview datagovtheme datajson_harvest datajson archiver qa googleanalyticsbasic extlink report broken_link_report saml2
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ solr:
 app:
   build: .
   environment:
-    CKAN_SITE_URL: http://localhost:5000
+    CKAN_SITE_URL: http://localhost:8080
   links:
     - redis
     - db
@@ -16,6 +16,7 @@ app:
     - /tmp/ckan/csv:/tmp/ckan/csv
   ports:
     - "5000:5000"
+    - "8080:80"
 harvester-fetch-consumer:
   build: .
   links:

--- a/docker/webserver/apache/wsgi.conf
+++ b/docker/webserver/apache/wsgi.conf
@@ -1,0 +1,6 @@
+<IfModule mod_wsgi.c>
+
+# Use our upgraded python for mod_wsgi
+WSGIPythonHome /usr/local/lib/python2.7.10
+
+</IfModule>

--- a/docker/webserver/entrypoint.sh
+++ b/docker/webserver/entrypoint.sh
@@ -39,7 +39,8 @@ if [ "$1" = 'app' ]; then
     ckan --plugin=ckanext-qa qa init
     ckan --plugin=ckanext-report report initdb
 
-    exec /usr/lib/ckan/bin/paster serve /etc/ckan/production.ini
+    source /etc/apache2/envvars
+    exec /usr/sbin/apache2 -DFOREGROUND
 
 elif [ "$1" = 'fetch-consumer' ]; then
     

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -17,6 +17,7 @@ chardet==2.3.0
 -e git+https://github.com/GSA/ckanext-harvest@2311ea86d1a6ca6c8be294a037d0cbe7d303922b#egg=ckanext_harvest
 -e git+https://github.com/GSA/ckanext-qa@2b3353cb3a36e021de448b7d280165a3dbfcf728#egg=ckanext_qa
 -e git+https://github.com/GSA/ckanext-report@f16607e700db67645734257a0c3ac74f4cbdb718#egg=ckanext_report
+-e git+https://github.com/GSA/ckanext-saml2@8415bbf470a9eb08df7fc38f050b833a1bd447dd#egg=ckanext_saml2
 -e git+https://github.com/GSA/ckanext-spatial@2a25f8d60c31add77e155c4136f2c0d4e3b86385#egg=ckanext_spatial
 decorator==3.4.0
 fanstatic==0.12
@@ -36,6 +37,7 @@ kombu==2.5.0
 kombu-sqlalchemy==1.1.0
 LEPL==5.1.3
 lxml==3.5.0
+M2Crypto==0.23.0
 Mako==0.9.0
 MarkupSafe==0.18
 meld3==1.0.2
@@ -59,6 +61,7 @@ pyasn1-modules==0.2.2
 Pygments==1.6
 Pylons==0.9.7
 pyparsing==1.5.6
+-e git+https://github.com/adborden/pysaml2.git@2916159f5366306fa059f81c89a4017319c06586#egg=pysaml2
 python-dateutil==1.5
 python-magic==0.4.12
 python-memcached==1.48

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -71,7 +71,7 @@ PyYAML==3.11
 -e git+https://github.com/asl2/PyZ3950.git@c2282c73182cef2beca0f65b1eb7699c9b24512e#egg=PyZ3950
 redis==2.10.1
 repoze.lru==0.6
-repoze.who==2.0
+repoze.who==1.0.18
 repoze.who-friendlyform==1.0.8
 requests==1.1.0
 rfc3987==1.3.5

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -17,7 +17,7 @@ chardet==2.3.0
 -e git+https://github.com/GSA/ckanext-harvest@2311ea86d1a6ca6c8be294a037d0cbe7d303922b#egg=ckanext_harvest
 -e git+https://github.com/GSA/ckanext-qa@2b3353cb3a36e021de448b7d280165a3dbfcf728#egg=ckanext_qa
 -e git+https://github.com/GSA/ckanext-report@f16607e700db67645734257a0c3ac74f4cbdb718#egg=ckanext_report
--e git+https://github.com/GSA/ckanext-saml2@8415bbf470a9eb08df7fc38f050b833a1bd447dd#egg=ckanext_saml2
+-e git+https://github.com/GSA/ckanext-saml2@aedc8a8154059d9511233c717e7938f1ac8b318b#egg=ckanext_saml2
 -e git+https://github.com/GSA/ckanext-spatial@2a25f8d60c31add77e155c4136f2c0d4e3b86385#egg=ckanext_spatial
 decorator==3.4.0
 fanstatic==0.12
@@ -61,7 +61,7 @@ pyasn1-modules==0.2.2
 Pygments==1.6
 Pylons==0.9.7
 pyparsing==1.5.6
--e git+https://github.com/adborden/pysaml2.git@2916159f5366306fa059f81c89a4017319c06586#egg=pysaml2
+-e git+https://github.com/tobes/pysaml2.git@1aead618565349532cd5f1e211c84496376ec6be#egg=pysaml2
 python-dateutil==1.5
 python-magic==0.4.12
 python-memcached==1.48

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ chardet==2.3.0
 -e git+https://github.com/GSA/ckanext-geodatagov@master#egg=ckanext-geodatagov
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@master#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-harvest@datagov#egg=ckanext-harvest
--e git+https://github.com/GSA/ckanext-saml2@adb-max#egg=ckanext-saml2
+-e git+https://github.com/GSA/ckanext-saml2@max#egg=ckanext-saml2
 -e git+https://github.com/GSA/ckanext-qa@datagov#egg=ckanext-qa
 -e git+https://github.com/GSA/ckanext-report@datagov#egg=ckanext-report
 -e git+https://github.com/GSA/ckanext-spatial@datagov#egg=ckanext-spatial

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,11 +15,12 @@ chardet==2.3.0
 -e git+https://github.com/GSA/ckanext-geodatagov@master#egg=ckanext-geodatagov
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@master#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-harvest@datagov#egg=ckanext-harvest
+-e git+https://github.com/GSA/ckanext-saml2@adb-max#egg=ckanext-saml2
 -e git+https://github.com/GSA/ckanext-qa@datagov#egg=ckanext-qa
 -e git+https://github.com/GSA/ckanext-report@datagov#egg=ckanext-report
 -e git+https://github.com/GSA/ckanext-spatial@datagov#egg=ckanext-spatial
 -e git+https://github.com/GSA/ckanext-ga-report@datagov#egg=ckanext-ga-report
--e git+https://github.com/GSA/PyZ3950@master#datagov#egg=PyZ3950
+-e git+https://github.com/GSA/PyZ3950@master#egg=PyZ3950
 
 decorator==3.4.0
 fanstatic==0.12
@@ -36,6 +37,11 @@ kombu==2.1.3
 kombu-sqlalchemy==1.1.0
 LEPL==5.1.3
 lxml==3.5.0
+
+# TODO upgrade to latest
+# match close to trusty's 0.21.1 while having an more up-to-date openssl symbols
+# https://packages.ubuntu.com/trusty/python-m2crypto
+M2Crypto==0.23.0
 Mako==0.9.0
 MarkupSafe==0.18
 meld3==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ pyutilib.component.core==4.5.3
 PyYAML==3.11
 redis==2.10.1
 repoze.lru==0.6
-repoze.who==2.0
+repoze.who==1.0.18
 repoze.who-friendlyform==1.0.8
 requests==1.1.0
 rfc3987==1.3.5

--- a/test.sh
+++ b/test.sh
@@ -6,8 +6,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-host="$APP_PORT_5000_TCP_ADDR"
-port="$APP_PORT_5000_TCP_PORT"
+host="$APP_PORT_80_TCP_ADDR"
+port="$APP_PORT_80_TCP_PORT"
 
 function test_setup () {
   echo waiting for app to startup...


### PR DESCRIPTION
Moving the saml2 dependency out of ansible and into requirements-freeze.txt. This makes it easier to detect when we are requiring incompatible dependencies earlier, rather than at deploy time. Currently, there is still a conflict with `repoze.who` between dev and production.