### PR TITLE
Requirements freeze

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,29 +4,31 @@ ENV CKAN_HOME /usr/lib/ckan
 ENV CKAN_CONFIG /etc/ckan/
 ENV CKAN_ENV docker
 
+WORKDIR /opt/catalog-app
+
 # Install required packages
 RUN apt-get -q -y update && apt-get -q -y install \
-	htop \
-	atool \
-	ruby \
-	python-virtualenv \
-	python-setuptools \
-	git \
-	python-dev \
-	ruby-dev \
-	postgresql-client \
-	bison \
-	apache2 \
-	libapache2-mod-wsgi \
-	python-pip \
-	libgeos-c1 \
-	libxml2-dev \
-	libxslt1-dev \
-	lib32z1-dev \
-	libpq-dev \
-        tomcat6 \
-        default-jdk \
-	wget
+  apache2 \
+  atool \
+  bison \
+  default-jdk \
+  git \
+  htop \
+  lib32z1-dev \
+  libapache2-mod-wsgi \
+  libgeos-c1 \
+  libpq-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  postgresql-client \
+  python-dev \
+  python-pip \
+  python-setuptools \
+  python-virtualenv \
+  ruby \
+  ruby-dev \
+  tomcat6 \
+  wget
 
 # copy ckan script to /usr/bin/
 COPY docker/webserver/common/usr/bin/ckan /usr/bin/ckan
@@ -39,8 +41,7 @@ RUN cd Python-2.7.10 && \
     make && make install
 
 # Upgrade pip & install virtualenv
-RUN pip install virtualenv && \
-    virtualenv $CKAN_HOME --no-site-packages -p /usr/local/lib/python2.7.10/bin/python
+RUN pip install virtualenv
 
 # Configure apache
 RUN rm -rf /etc/apache2/sites-enabled/000-default.conf
@@ -51,7 +52,6 @@ RUN a2enmod rewrite headers
 # Install & Configure CKAN app
 COPY install.sh /
 COPY requirements-freeze.txt /
-COPY requirements.txt /
 COPY docker/webserver/config/ckan_config.sh $CKAN_HOME/bin/
 
 # Config CKAN app
@@ -61,9 +61,7 @@ RUN ln -s $CKAN_HOME/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini
 RUN mkdir /var/tmp/ckan && chown www-data:www-data /var/tmp/ckan
 
 # Install ckan app
-RUN cd / && \
-    sh install.sh && \
-    mkdir -p $CKAN_CONFIG
+RUN cd / && ./install.sh
 
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
@@ -74,4 +72,4 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 EXPOSE 5000
 
-CMD ["/usr/lib/ckan/bin/paster","serve","/etc/ckan/production.ini"]
+CMD ["app","--wait-for-dependencies"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,23 @@
-.PHONY: all build test
+.PHONY: all build copy-src local requirements setup test update-dependencies
+
+CKAN_HOME := /usr/lib/ckan
 
 all: build
 
 build:
 	docker-compose build
 
+local:
+	docker-compose -f docker-compose.yml -f docker-compose.local.yml up
+
 requirements:
-	docker-compose run --rm -T app pip freeze > requirements-freeze.txt
+	docker-compose run --rm -T app pip --quiet freeze > requirements-freeze.txt
+
+update-dependencies:
+	docker-compose run --rm app ./install-dev.sh
+
+copy-src:
+	docker cp catalog-app_app_1:$(CKAN_HOME)/src .
 
 test:
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ all: build
 build:
 	docker-compose build
 
+requirements:
+	docker-compose run --rm -T app pip freeze > requirements-freeze.txt
+
 test:
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml build
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up test

--- a/README.md
+++ b/README.md
@@ -62,12 +62,16 @@ The application is deployed using [docker-compose](https://docs.docker.com/compo
 
 ### Quick Start
 After docker-compose installs check to make sure docker daemon running: `sudo service docker status` if not `sudo service docker start`
+
 ```
 git clone https://github.com/GSA/catalog-app
 cd catalog-app
-sudo docker-compose up
+docker-compose up
 ```
-If you do not wish to run docker as root user (i.e. `sudo`), you can add your UNIX user to the docker with `sudo useradd -G {{user}} docker`
+
+_Note: We assume your user is already added to the docker group (`sudo useradd
+-G ${user} docker`). Alternatively, you can run docker-compose with `sudo`._
+
 
 ### catalog-app stack:
 * solr
@@ -189,31 +193,44 @@ Once running you can use either/both [docker commands](https://docs.docker.com/e
 2. Install **docker tool box**: `brew cask install dockertoolbox`
 3. Create a **docker machine**: `docker-machine create --driver virtualbox --virtualbox-cpu-count "4" --virtualbox-memory "2048" default`
 
+
 ### Source Code Folder (**src**):
 **Note:** follow these steps only if your src folder is empty or you need the latest code
 
-1. Start the app, from root folder run: `docker-compose up`
-2. Move app source files to your local src folder (`{app_path_on_your_machine}/src`): `docker cp catalogapp_app_1:/usr/lib/ckan/src .`
-3. Stop the app: `docker-compose down`
+1. Start the app, from root folder.
+
+    $ docker-compose up
+
+1. Copy app source files to your local src folder.
+
+    $ make copy-src
+
+1. Stop the app: `docker-compose down`
+
 
 ### Workflow:
-1. Start the app in local mode (this will mount the `src` folder from your local machine to the app's container `/usr/lib/ckan/src` folder)
-`docker-compose -f docker-compose.yml -f docker-compose.local.yml up`
-2. Make changes to the source code(`src` folder) and commit it to github (the extensions used by the app are in `requirements.txt`)
-3. Restart apache to see your changes in action:
-`docker exec -it {app_container_name} service apache2 restart`
-4. Optional: to get the latest code from ckan extensions part of requirements.txt run the following command: `docker-compose exec app /usr/lib/ckan/bin/pip install -r requirements.txt`
-5. In order for the catalog-app to see commits made to repositories in requirements.txt run the following command and commit the new `requirements-freeze.txt`: `docker-compose exec app /usr/lib/ckan/bin/pip -q freeze > requirements-freeze.txt`
 
-see: `https://blog.engineyard.com/2014/composer-its-all-about-the-lock-file`
-the same concepts apply to pip
+1. Start the app in local mode.
 
-### Manual regenerating requirements-freeze.txt
-    $ virtualenv test
-    $ cd test
-    $ source ./bin/activate
-    $ pip install -r requirements.txt
-    $ pip freeze > requirements-freeze.txt
+    $ make local
+
+1. Make changes to the source code in `src`.
+1. Restart apache to see your changes in action.
+
+    $ docker-compose exec app service apache2 restart
+
+1. Commit the changes, and push extensions to GitHub.
+1. (optional) Pull in the latest dependencies, including nested dependencies.
+
+    $ make update-dependencies
+
+1. Update the pinned requirements in `requirements-freeze.txt`.
+
+    $ make requirements
+
+see: https://blog.engineyard.com/2014/composer-its-all-about-the-lock-file
+the same concepts apply to pip.
+
 
 ### Troubleshooting:
  "Cannot connect to the Docker daemon. Is the docker daemon running on this host?"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ app:
     - fgdc2iso
   command: app --wait-for-dependencies
   volumes:
-    - /tmp/ckan/csv:/tmp/ckan/csv
+    - .:/opt/catalog-app
     - ckan:/usr/lib/ckan
+    - /tmp/ckan/csv:/tmp/ckan/csv
   ports:
     - "5000:5000"
 harvester-fetch-consumer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ app:
   command: app --wait-for-dependencies
   volumes:
     - /tmp/ckan/csv:/tmp/ckan/csv
+    - ckan:/usr/lib/ckan
   ports:
     - "5000:5000"
 harvester-fetch-consumer:

--- a/docker/webserver/entrypoint.sh
+++ b/docker/webserver/entrypoint.sh
@@ -3,8 +3,15 @@
 set -o errexit
 set -o pipefail
 
+# Silence ckan_config.sh when not run in a tty (better for piping output)
+fd="/dev/stdout"
+if [[ ! -t 0 ]]; then
+  # Not a tty
+  fd=/dev/null
+fi
+
 # configure /etc/ckan/production.ini
-/bin/sh /usr/lib/ckan/bin/ckan_config.sh
+/bin/sh /usr/lib/ckan/bin/ckan_config.sh > $fd
 
 function wait-for-dependencies () {
   local address="$1"
@@ -53,7 +60,10 @@ elif [ "$1" = 'gather-consumer' ]; then
 
     #ckan harvester initdb
     ckan --plugin=ckanext-harvest harvester gather_consumer
-else
-    # execute any other command
-    exec $@
 fi
+
+# activate the virutal environment
+source /usr/lib/ckan/bin/activate
+
+# execute any other command
+exec "$@"

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Initializes the development environment by installing the app dependencies.
+# We assume you already have your virtualenv activated.
+
+if [[ -z "$VIRTUAL_ENV" ]]; then
+  echo You must activate your python virutal environment first. >&2
+  exit 1
+fi
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+pip install -r requirements.txt
+
+# Install development dependencies of extensions
+# TODO extensions should declare runtime dependencies in setup.py
+EXTENSIONS=$(cat requirements.txt | grep -o "egg=.*" | cut -f2- -d'=')
+
+# install/setup each extension individually
+for extension in $EXTENSIONS; do
+    if [ -f $VIRTUAL_ENV/src/$extension/requirements.txt ]; then
+        $VIRTUAL_ENV/bin/pip install -r $VIRTUAL_ENV/src/$extension/requirements.txt
+    elif [ -f $VIRTUAL_ENV/src/$extension/pip-requirements.txt ]; then
+        $VIRTUAL_ENV/bin/pip install -r $VIRTUAL_ENV/src/$extension/pip-requirements.txt
+    fi
+done

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,3 +1,4 @@
+amqp==1.0.13
 amqplib==1.0.2
 anyjson==0.3.3
 Babel==0.9.6
@@ -5,40 +6,44 @@ Beaker==1.6.4
 boto==2.48.0
 celery==2.4.2
 chardet==2.3.0
--e git+https://github.com/GSA/ckan.git@datagov#egg=ckan
--e git+https://github.com/GSA/ckanext-archiver@datagov#egg=ckanext_archiver
--e git+https://github.com/GSA/ckanext-datagovtheme@master#egg=ckanext_datagovtheme
--e git+https://github.com/GSA/ckanext-datajson@datagov#egg=ckanext_datajson
--e git+https://github.com/GSA/ckanext-extlink@master#egg=ckanext_extlink
--e git+https://github.com/GSA/ckanext-geodatagov@master#egg=ckanext_geodatagov
--e git+https://github.com/GSA/ckanext-googleanalyticsbasic@master#egg=ckanext_googleanalyticsbasic
--e git+https://github.com/GSA/ckanext-harvest@datagov#egg=ckanext_harvest
--e git+https://github.com/GSA/ckanext-qa@datagov#egg=ckanext_qa
--e git+https://github.com/GSA/ckanext-report@datagov#egg=ckanext_report
--e git+https://github.com/GSA/ckanext-spatial@datagov#egg=ckanext_spatial
--e git+https://github.com/GSA/ckanext-ga-report@datagov#egg=ckanext_ga_report
--e git+https://github.com/GSA/PyZ3950@master#datagov#egg=PyZ3950
+-e git+https://github.com/GSA/ckan.git@3ef06a35dfe51ec8ecb1a56fa6c372568e3f039a#egg=ckan
+-e git+https://github.com/GSA/ckanext-archiver@bb4d85b5db628cd2a6d576c3fde79ddc0d9b5952#egg=ckanext_archiver
+-e git+https://github.com/GSA/ckanext-datagovtheme@4eea2c54bed9d1e3e679411bbc5b0730eb1a03c9#egg=ckanext_datagovtheme
+-e git+https://github.com/GSA/ckanext-datajson@3205ba3f9af9c37fb0adaed3023c701c23c5cc21#egg=ckanext_datajson
+-e git+https://github.com/GSA/ckanext-extlink@69629853f6c7aa4f94c105c5efd76380d70f0843#egg=ckanext_extlink
+-e git+https://github.com/GSA/ckanext-ga-report@7d32eac6db1bc68dd8f3f96f14c6fd3aeec902a9#egg=ckanext_ga_report
+-e git+https://github.com/GSA/ckanext-geodatagov@80b72945926134f0d9d3fb59741284332672cac4#egg=ckanext_geodatagov
+-e git+https://github.com/GSA/ckanext-googleanalyticsbasic@0b90194d77938e59ecb7d6937c201bd6815447f8#egg=ckanext_googleanalyticsbasic
+-e git+https://github.com/GSA/ckanext-harvest@2311ea86d1a6ca6c8be294a037d0cbe7d303922b#egg=ckanext_harvest
+-e git+https://github.com/GSA/ckanext-qa@2b3353cb3a36e021de448b7d280165a3dbfcf728#egg=ckanext_qa
+-e git+https://github.com/GSA/ckanext-report@f16607e700db67645734257a0c3ac74f4cbdb718#egg=ckanext_report
+-e git+https://github.com/GSA/ckanext-spatial@2a25f8d60c31add77e155c4136f2c0d4e3b86385#egg=ckanext_spatial
 decorator==3.4.0
 fanstatic==0.12
 Flask==0.8
 FormEncode==1.2.6
+gdata==2.0.18
 Genshi==0.6
 GeoAlchemy==0.7.2
 GeoAlchemy2==0.2.6
+google-api-python-client==1.4.1
 html5lib==0.9999999
+httplib2==0.11.3
 Jinja2==2.6
 json-table-schema==0.2.1
 jsonschema==2.4.0
-kombu==2.1.3
+kombu==2.5.0
 kombu-sqlalchemy==1.1.0
 LEPL==5.1.3
 lxml==3.5.0
 Mako==0.9.0
 MarkupSafe==0.18
 meld3==1.0.2
-messytables==0.15.0
+messytables==0.15.2
 nose==1.3.0
+oauth2client==1.4.12
 ofs==0.4.1
+-e git+https://github.com/GSA/OWSLib.git@71a43028777bc982d993876d925699af830e2839#egg=OWSLib
 Pairtree===0.7.1-T
 passlib==1.6.2
 Paste==1.7.5.1
@@ -47,16 +52,20 @@ PasteScript==1.7.5
 pbr==0.8.2
 pika==0.9.8
 ply==3.4
+progressbar==2.3
 psycopg2==2.4.5
+pyasn1==0.4.4
+pyasn1-modules==0.2.2
 Pygments==1.6
 Pylons==0.9.7
 pyparsing==1.5.6
 python-dateutil==1.5
-python-magic==0.4.10
+python-magic==0.4.12
 python-memcached==1.48
 pytz==2016.1
 pyutilib.component.core==4.5.3
 PyYAML==3.11
+-e git+https://github.com/asl2/PyZ3950.git@c2282c73182cef2beca0f65b1eb7699c9b24512e#egg=PyZ3950
 redis==2.10.1
 repoze.lru==0.6
 repoze.who==2.0
@@ -64,6 +73,7 @@ repoze.who-friendlyform==1.0.8
 requests==1.1.0
 rfc3987==1.3.5
 Routes==1.13
+rsa==3.4.2
 Shapely==1.3.1
 simplejson==3.3.1
 six==1.7.3
@@ -74,11 +84,12 @@ sqlparse==0.1.11
 supervisor==3.2.2
 Tempita==0.5.2
 unicodecsv==0.9.4
+uritemplate==3.0.0
 vdm==0.13
 WebError==0.10.3
 WebHelpers==1.3
 WebOb==1.0.8
 WebTest==1.4.3
 Werkzeug==0.11.4
-xlrd==0.9.4
+xlrd==1.0.0
 zope.interface==4.1.1


### PR DESCRIPTION
At some point we stopped using requirements-freeze.txt as a lock file and now we install different versions of dependencies in development and production because the versions of our dependencies are incompatible. This restores requirements-freeze.txt to pinning dependency versions.