### PR TITLE
Upgrade setuptools for deployments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ if [ -f "$python_home/bin/python" ]; then
 fi
 virtualenv "$venv" $virtualenv_opts
 
-# upgrade pip
-"$pip" install -U pip==8.1.1
+# upgrade pip and setuptools
+"$pip" install -U pip==8.1.1 setuptools==40.5.0
 
 # install ckan core + ckan extensions
 "$pip" install -r requirements-freeze.txt

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -46,7 +46,7 @@ nose==1.3.0
 oauth2client==1.4.12
 ofs==0.4.1
 -e git+https://github.com/GSA/OWSLib.git@71a43028777bc982d993876d925699af830e2839#egg=OWSLib
-Pairtree===0.7.1-T
+Pairtree==0.7.1-T
 passlib==1.6.2
 Paste==1.7.5.1
 PasteDeploy==1.5.0
@@ -77,6 +77,7 @@ requests==1.1.0
 rfc3987==1.3.5
 Routes==1.13
 rsa==3.4.2
+setuptools==40.5.0
 Shapely==1.3.1
 simplejson==3.3.1
 six==1.7.3


### PR DESCRIPTION
datagov-deploy kitchen tests are failing on catalog playbooks, complaining that setuptools is too old. This adds a step to upgrade it before installing requirements.txt.