### PR TITLE
Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,17 @@
+pipeline {
+  agent any
+  stages {
+    stage('deploy') {
+      when { anyOf { branch 'master' } }
+      environment {
+        ANSIBLE_VAULT_FILE = credentials('ansible-vault-secret')
+        SSH_KEY_FILE = credentials('datagov-sandbox')
+      }
+      steps {
+        ansiColor('xterm') {
+          sh 'docker run --rm -v $SSH_KEY_FILE:$SSH_KEY_FILE -v $ANSIBLE_VAULT_FILE:$ANSIBLE_VAULT_FILE -u $(id -u) datagov/datagov-deploy:latest pipenv run ansible-playbook --key-file=$SSH_KEY_FILE --vault-password-file=$ANSIBLE_VAULT_FILE --inventory inventories/ci --skip-tags database catalog.yml'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of https://github.com/gsa/datagov-deploy/issues/1032

This adds a Jenkinsfile for automated deployment from our Jenkins instance.

It's missing the CircleCI configuration and [jenkins_build script](https://github.com/GSA/datagov-deploy/issues/1340) to trigger the Jenkins job on successful builds to master.

Even without the CI configuration, Jenkins could be used for push-button deploy.