### PR TITLE
Fixes README & docker-compose for running harvesters locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Enter the URL to the appropriate endpoint to the "Source type" used, enter a tit
 
 Queue any scheduled harvest jobs.
 
-    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester run
+    $ docker-compose run --rm app ckan --plugin=ckanext-harvest harvester run
 
 Start the gather consumer.
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ Queue any scheduled harvest jobs.
 
 Start the gather consumer.
 
-    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester gather_consumer
+    $ docker-compose run --rm app ckan --plugin=ckanext-harvest harvester gather_consumer
 
 Start the fetch consumer.
 
-    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester fetch_consumer
+    $ docker-compose run --rm app ckan --plugin=ckanext-harvest harvester fetch_consumer
 
 Mark any completed jobs as finished.
 
-    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester run
+    $ docker-compose run --rm app ckan --plugin=ckanext-harvest harvester run
 
 
 #### fgdc2iso

--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ Enter the URL to the appropriate endpoint to the "Source type" used, enter a tit
 
 Queue any scheduled harvest jobs.
 
-    $ docker-compose run --rm app ckan harvest harvest_run
+    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester run
 
 Start the gather consumer.
 
-    $ docker-compose run --rm app ckan harvest gather-consumer
+    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester gather_consumer
 
 Start the fetch consumer.
 
-    $ docker-compose run --rm app ckan harvest fetch-consumer
+    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester fetch_consumer
 
 Mark any completed jobs as finished.
 
-    $ docker-compose run --rm app ckan harvest harvest_run
+    $ docker-compose run -d --no-deps app ckan --plugin=ckanext-harvest harvester run
 
 
 #### fgdc2iso

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       DATABASE_URL: postgresql://ckan:ckan@db/ckan
       SOLR_URL: http://solr:8983/solr/ckan
       FGDC2ISO_URL: http://fgdc2iso:8080/fgdc2iso
-      REDIS_URL: redis:6379
+      REDIS_URL: redis
     depends_on:
       - redis
       - db


### PR DESCRIPTION
A few fixes I made after getting stuck running the harvesters on a local machine - 

- Fixed REDIS url (doesn't need to specify the port)
- Fixed the example commands in the README.