### PR TITLE
Fix make local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean copy-src local requirements setup test update-dependencies
+.PHONY: all build clean copy-src local requirements setup test up update-dependencies
 
 CKAN_HOME := /usr/lib/ckan
 
@@ -10,18 +10,21 @@ build:
 clean:
 	docker-compose down -v --remove-orphans
 
+copy-src:
+	docker cp catalog-app_app_1:$(CKAN_HOME)/src .
+
 local:
 	docker-compose -f docker-compose.yml -f docker-compose.local.yml up
 
 requirements:
 	docker-compose run --rm -T app pip --quiet freeze > requirements-freeze.txt
 
-update-dependencies:
-	docker-compose run --rm app ./install-dev.sh
-
-copy-src:
-	docker cp catalog-app_app_1:$(CKAN_HOME)/src .
-
 test:
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml build
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up test
+
+update-dependencies:
+	docker-compose run --rm -T app pip install -r requirements.txt
+
+up:
+	docker-compose up

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,3 +1,5 @@
-app:
-  volumes:
-   - ./src:/usr/lib/ckan/src
+version: "3"
+services:
+  app:
+    volumes:
+     - ./src:/usr/lib/ckan/src


### PR DESCRIPTION
After some recent (or not recent) changes to catalog-app, we broke `make local`
and the update dependencies workflow.