### PR TITLE
Failing tests don't error on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ requirements:
 
 test:
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml build
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml up test
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
 
 update-dependencies:
 	docker-compose run --rm -T app pip install -r requirements.txt

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ host="app"
 port="80"
 
 function test_setup () {
-  local retries=5
+  local retries=10
   while ! nc -w 60 -z "$host" "$port"; do
     if [ "$retries" -le 0 ]; then
       echo "app did not start" >&2


### PR DESCRIPTION
Make sure to exit with the container exit code.

Also updates the retries, since ckan seems to take longer than before to start
up.