### PR TITLE
Fix ckanext-saml2

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -37,6 +37,7 @@ jsonschema==2.4.0
 kombu==2.5.0
 LEPL==5.1.3
 lxml==4.5.0
+M2Crypto==0.23.0
 Mako==1.1.2
 MarkupSafe==1.1.1
 messytables==0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,6 +85,7 @@ progressbar==2.3
 
 # ckanext-saml2
 -e git+https://github.com/GSA/pysaml2.git@max#egg=pysaml2
+M2Crypto==0.23.0
 
 
 # ckanext-spatial


### PR DESCRIPTION
Missing required M2Crypto library for pysaml2.

Ran into this when testing on staging.