### PR TITLE
WIP: add ckanext-harvest

### DIFF
--- a/.env.catalog
+++ b/.env.catalog
@@ -40,12 +40,12 @@ CKAN_SMTP_MAIL_FROM=ckan@localhost
 
 # Extensions
 
-CKAN__PLUGINS=envvars image_view text_view recline_view datastore
+CKAN__PLUGINS=envvars image_view text_view recline_view datastore harvest ckan_harvester 
 
 # Harvest settings
-# CKAN__HARVEST__MQ__TYPE=redis
-# CKAN__HARVEST__MQ__HOSTNAME=redis
-# CKAN__HARVEST__MQ__PORT=6379
-# CKAN__HARVEST__MQ__REDIS_DB=1
-# CKAN__HARVEST__LOG_LEVEL=info
-# CKAN__HARVEST__LOG_SCOPE=0
+CKAN__HARVEST__MQ__TYPE=redis
+CKAN__HARVEST__MQ__HOSTNAME=redis
+CKAN__HARVEST__MQ__PORT=6379
+CKAN__HARVEST__MQ__REDIS_DB=1
+CKAN__HARVEST__LOG_LEVEL=info
+CKAN__HARVEST__LOG_SCOPE=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,12 @@ ARG TZ=UTC
 RUN echo $TZ > /etc/timezone
 RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
 
+RUN apk add libffi-dev
+
 COPY docker/ckan-entrypoint.d/* /docker-entrypoint.d/
 
 RUN mkdir -p /var/lib/ckan/storage/uploads
 RUN chown -R ckan:ckan /var/lib/ckan/storage
 
-# TODO start ainstalling reqs
-# COPY requirements.txt .
-# RUN pip install -r requirements.txt
+COPY requirements.txt .
+RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ COPY docker/ckan-entrypoint.d/* /docker-entrypoint.d/
 RUN mkdir -p /var/lib/ckan/storage/uploads
 RUN chown -R ckan:ckan /var/lib/ckan/storage
 
+RUN pip install --upgrade pip
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/docker/ckan-entrypoint.d/200-ckanext-harvest.sh
+++ b/docker/ckan-entrypoint.d/200-ckanext-harvest.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Init DB for ckanext-harvest"
+paster --plugin=ckanext-harvest harvester initdb $CKAN_INI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
 
 
-# ckanext-harvest
--e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext-harvest
-# https://github.com/ckan/ckanext-harvest/blob/master/pip-requirements.txt
-pika>=1.1.0
-redis>=3.3.0
-requests==2.20.0
-pyOpenSSL==18.0.0
-ckantoolkit==0.0.3
+# ckanext-harvest [master is working with ckan 2.9, do not use it]
+ -e git+https://github.com/ckan/ckanext-harvest.git@v1.1.4#egg=ckanext-harvest
+ -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.1.4/pip-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,101 +1,10 @@
-#ckan extensions
--e git+https://github.com/GSA/ckanext-archiver@datagov#egg=ckanext-archiver
--e git+https://github.com/GSA/ckanext-datagovtheme@master#egg=ckanext-datagovtheme
--e git+https://github.com/GSA/ckanext-datajson@datagov#egg=ckanext-datajson
--e git+https://github.com/GSA/ckanext-extlink@master#egg=ckanext-extlink
--e git+https://github.com/GSA/ckanext-geodatagov@master#egg=ckanext-geodatagov
--e git+https://github.com/GSA/ckanext-googleanalyticsbasic@master#egg=ckanext-googleanalyticsbasic
--e git+https://github.com/GSA/ckanext-harvest@datagov#egg=ckanext-harvest
--e git+https://github.com/GSA/ckanext-saml2@max#egg=ckanext-saml2
--e git+https://github.com/GSA/ckanext-qa@datagov#egg=ckanext-qa
--e git+https://github.com/GSA/ckanext-report@datagov#egg=ckanext-report
--e git+https://github.com/GSA/ckanext-spatial@datagov#egg=ckanext-spatial
--e git+https://github.com/GSA/ckanext-ga-report@datagov#egg=ckanext-ga-report
-
-# ckan requirements.txt
-Babel>=0.9.6,<1.0.0  # newer versions cause problems with when switching languages
-Jinja2==2.6  # newer version causes problem in CkanInternationalizationExtension.parse
-                         # when creating a new dataset
-Pylons==0.9.7
-Genshi==0.6
-WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
-fanstatic==0.12
-ofs==0.4.1
-Pairtree==0.7.1-T
-Paste==1.7.5.1
-PasteScript~=1.7.5
-passlib==1.6.2
-psycopg2==2.4.5
-python-dateutil>=1.5.0,<2.0.0
-pyutilib.component.core==4.5.3
-repoze.who-friendlyform==1.0.8
-# CKAN requires 2.0 but ckanext-saml2 requires 1.0.18
-repoze.who==1.0.18
-requests~=2.20.0
-Routes==1.13
-solrpy==0.9.5
-sqlalchemy-migrate==0.9.1
-SQLAlchemy==0.9.6
-vdm==0.13
-sqlparse==0.1.11
-WebHelpers==1.3
-WebOb==1.0.8
-zope.interface==4.1.1
-unicodecsv>=0.9
-
-
-# ckanext-archiver
-celery==2.4.2
-kombu==2.5
-progressbar==2.3
-SQLAlchemy==0.9.6
-
-
-# ckanext-datajson
-pyyaml
-lepl
-jsonschema~=2.4.0
-rfc3987
-
-
-# ckanext-ga-report
-google-api-python-client==1.4.1
-oauth2client==1.4.12
-
-
-# ckanext-geodatagov
--e git+https://github.com/asl2/PyZ3950@master#egg=PyZ3950
-ply==3.4
-boto
 
 
 # ckanext-harvest
-pika==0.9.8
-redis==2.10.1
-
-
-# ckanext-qa
-SQLAlchemy==0.9.6
-xlrd==1.0.0
-python-magic==0.4.12
-messytables==0.15.2
-progressbar==2.3
-
-
-# ckanext-saml2
--e git+https://github.com/GSA/pysaml2.git@max#egg=pysaml2
-
-
-# ckanext-spatial
-GeoAlchemy>=0.6
-GeoAlchemy2>=0.2.4
-Shapely==1.3.1
--e git+https://github.com/GSA/OWSLib.git@catalog-0.8.6#egg=owslib
-lxml>=2.3
-argparse
-pyparsing==1.5.6
-Jinja2==2.6
-
-
-# OWSLib
-pytz
+-e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages
+# https://github.com/ckan/ckanext-harvest/blob/master/pip-requirements.txt
+pika>=1.1.0
+redis>=3.3.0
+requests==2.20.0
+pyOpenSSL==18.0.0
+ckantoolkit==0.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 
 
 # ckanext-harvest
--e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages
+-e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext-harvest
 # https://github.com/ckan/ckanext-harvest/blob/master/pip-requirements.txt
 pika>=1.1.0
 redis>=3.3.0


### PR DESCRIPTION
About [#1408](https://github.com/GSA/datagov-deploy/issues/1408) 

 - ckanext-harvest upstream added (version 1.1.4 because master and 1.2.0 fails with ckan 2.8)
 - Upgrade pip
 - tested locally: don't start automatically but it's working if I run harvester manually

![image](https://user-images.githubusercontent.com/3237309/79876752-d002e980-83c1-11ea-86ce-575d76e345e8.png)

Note: Tests fails since I'm usin [catalog-db](https://github.com/avdata99/catalog-db/pull/1) and [catalog-solr](https://github.com/avdata99/catalog-solr/pull/1) from updates not yet validated.
PR over _update_test_bats_ branch.