### PR TITLE
Fix broken bats installation in bionic CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,13 @@ jobs:
       - run:
           name: Installing bats
           command: |
-            git clone https://github.com/bats-core/bats-core.git
+            git clone --branch v1.2.0 https://github.com/bats-core/bats-core.git
             ./bats-core/install.sh ~
       - persist_to_workspace:
           root: /home/circleci
           paths:
             - bin
+            - lib
             - libexec
 
   deploy:


### PR DESCRIPTION
Also pin version of bats to 1.2.0 so we don't get surprised in the future.