### PR TITLE
Check shipped code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir /var/tmp/ckan && chown www-data:www-data /var/tmp/ckan
 # Install ckan app
 COPY . /opt/catalog-app
 WORKDIR /opt/catalog-app
-RUN $CKAN_HOME/bin/pip install -r REQUIREMENTS_FILE
+RUN $CKAN_HOME/bin/pip install -r $REQUIREMENTS_FILE
 
 # copy ckan script to /usr/bin/
 COPY docker/webserver/common/usr/bin/ckan /usr/bin/ckan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
 
 ARG PYTHON_VERSION=2.7.10
+ARG REQUIREMENTS_FILE=requirements.txt
 
 ENV CKAN_HOME /usr/lib/ckan
 ENV CKAN_CONFIG /etc/ckan/
@@ -69,7 +70,7 @@ RUN mkdir /var/tmp/ckan && chown www-data:www-data /var/tmp/ckan
 # Install ckan app
 COPY . /opt/catalog-app
 WORKDIR /opt/catalog-app
-RUN $CKAN_HOME/bin/pip install -r requirements.txt
+RUN $CKAN_HOME/bin/pip install -r REQUIREMENTS_FILE
 
 # copy ckan script to /usr/bin/
 COPY docker/webserver/common/usr/bin/ckan /usr/bin/ckan

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CKAN_HOME := /usr/lib/ckan
 all: build
 
 build:
-	docker-compose build
+	docker-compose build --build-arg REQUIREMENTS_FILE app
 
 clean:
 	docker-compose down -v --remove-orphans
@@ -20,7 +20,7 @@ requirements:
 	docker-compose run --rm -T app pip --quiet freeze > requirements-freeze.txt
 
 test:
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml build
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml build --build-arg REQUIREMENTS_FILE app
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
 
 update-dependencies:

--- a/README.md
+++ b/README.md
@@ -144,12 +144,14 @@ Follow these steps only if your `src` folder is empty or you need the latest cod
 1. Commit the changes, and push extensions to GitHub.
 
 ### Update Dependencies
-1. Update the pinned requirements in `requirements-freeze.txt`. **Because of a version conflict for repoze.who, special care should be taken to make sure that repoze.who==1.0.18 is shipped to production in order to be compatible with ckanext-saml2. After generating the requirements-freeze.txt, manually review the file to make sure the versions are correct. See https://github.com/GSA/catalog-app/issues/78 for more details.** An initialized container will have the repoze.who version overwritten by the workaround script in entrypoint script, so we add `clean`, `build` to make sure the container is fresh. Then the dependencies are updated via `update-dependencies` and then added to the `requirements-freeze.txt` file:
+Update the pinned requirements in `requirements-freeze.txt`. **Because of a version conflict for repoze.who, special care should be taken to make sure that repoze.who==1.0.18 is shipped to production in order to be compatible with ckanext-saml2. After generating the requirements-freeze.txt, manually review the file to make sure the versions are correct. See https://github.com/GSA/catalog-app/issues/78 for more details.** An initialized container will have the repoze.who version overwritten by the workaround script in entrypoint script, so we add `clean`, `build` to make sure the container is fresh. Then the dependencies are updated via `update-dependencies` and then added to the `requirements-freeze.txt` file:
 
     $ make clean build update-dependencies requirements
 
-see: https://blog.engineyard.com/2014/composer-its-all-about-the-lock-file
-the same concepts apply to pip.
+Circle Ci will run the test against the `requirements-freeze.txt` file, while local development runs against `requirements.txt`. This is intentional, to make a simple dev environment and an easy way to update dependencies while verifying against shipped code for production.
+
+*see: https://blog.engineyard.com/2014/composer-its-all-about-the-lock-file*
+*the same concepts apply to pip.*
 
 
 ## Tests


### PR DESCRIPTION
Uses a variable to pull in `requirements.txt` file to run pip install against, defaults to dev (`requirements.txt`). [CircleCi environment variable](https://app.circleci.com/settings/project/github/GSA/catalog-app/environment-variables?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2FGSA%2Fcatalog-app) already added so that it will run against `requirements-freeze.txt`.