### PR TITLE
Update README with fgdc2iso information

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Mark any completed jobs as finished.
 
 For some harvest sources with [CSDGM](https://www.fgdc.gov/metadata/csdgm-standard) metadata records, you must have fgdc2iso properly configured with
 a SaxonPE license. See the [GSA/catalog-fgdc2iso](https://github.com/GSA/catalog-fgdc2iso) for building the fgdc2iso WAR file. 
-See [GSA/datagov-deploy](https://github.com/GSA/datagov-deploy) for deploying the the fgdc2iso application.
+See [GSA/datagov-deploy-fgdc2iso](https://github.com/GSA/datagov-deployfgdc2iso) and [GSA/datagov-deploy](https://github.com/GSA/datagov-deploy) for deploying the the fgdc2iso application.
 
 
 ### CKAN/catalog-app commands

--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ Mark any completed jobs as finished.
 
 #### fgdc2iso
 
-_TODO: complete this section._
-
-For some harvest source types, you must have fgdc2iso properly configured with
-a SaxonPE license. See the [GSA/datagov-deploy] and the Ansible vault.
+For some harvest sources with [CSDGM](https://www.fgdc.gov/metadata/csdgm-standard) metadata records, you must have fgdc2iso properly configured with
+a SaxonPE license. See the [GSA/catalog-fgdc2iso](https://github.com/GSA/catalog-fgdc2iso) for building the fgdc2iso WAR file. 
+See [GSA/datagov-deploy](https://github.com/GSA/datagov-deploy) for deploying the the fgdc2iso application.
 
 
 ### CKAN/catalog-app commands


### PR DESCRIPTION
Updated the README with the latest information for building releases of the fgdc2iso WAR file and deploying the fgdc2iso service.

This is in reference to "Make the fgdc2iso service its own app"
https://github.com/gsa/datagov-deploy/issues/865