### PR TITLE
[ci] use buildWithParameters for jenkins build

### DIFF
--- a/bin/jenkins_build
+++ b/bin/jenkins_build
@@ -17,8 +17,6 @@ Environment variables are required:
 
   JENKINS_API_TOKEN the API token for the user, see \$JENKINS_URL/user/<user-name>/configure.
 
-  JENKINS_JOB_TOKEN the secret authorization token for this job, see \$JENKINS_URL/job/<job-name>/configure.
-
   JENKINS_USER the username to access the API as.
 EOF
 
@@ -33,26 +31,14 @@ function jenkins_curl () {
   curl --silent --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" "$@" "${JENKINS_URL}${url}"
 }
 
-function crumb_header () {
-  # Get a CRSF token (crumb) from Jenkins
-  local crumb_response crumb_header crumb_value
-
-  # Create a temp file for processing the response
-  crumb_response=$(mktemp)
-
-  jenkins_curl /crumbIssuer/api/json > "$crumb_response"
-  crumb_header=$(jq --raw-output .crumbRequestField "$crumb_response")
-  crumb_value=$(jq --raw-output .crumb "$crumb_response")
-  rm -rf "$crumb_response"
-  echo -n "$crumb_header:$crumb_value"
-}
-
 function build_job () {
   local job_name
   job_name=$1
 
-  jenkins_curl "/job/${job_name}/build?token=$JENKINS_JOB_TOKEN" -X POST -H "$(crumb_header)"
-  echo "$job_name" started.
+  jenkins_curl "/job/${job_name}/buildWithParameters" -X POST \
+    --data "branch_name=${CIRCLE_BRANCH}" \
+    --data "cause=${CIRCLE_BUILD_URL:-build script}"
+  echo "$job_name started for branch=$CIRCLE_BRANCH."
 }
 
 
@@ -64,11 +50,6 @@ fi
 
 if [[ -z "${JENKINS_API_TOKEN:-}" ]]; then
   echo \$JENKINS_API_TOKEN is not set. >&2
-  usage
-fi
-
-if [[ -z "${JENKINS_JOB_TOKEN:-}" ]]; then
-  echo \$JENKINS_JOB_TOKEN is not set. >&2
   usage
 fi
 


### PR DESCRIPTION
Jenkins job now uses the branch_name parameter, make sure to call
buildWithParameters.

We are building as the ci user with an API token. The job token and csrf token
are not necessary.